### PR TITLE
Fix lein dependency typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is a fairly simple library, but it’s handy to have.
 To install, just add the following to your project :dependencies:
 
 ```clojure
-[io.clojure.liberator-transit "0.2.0"]
+[io.clojure/liberator-transit "0.2.0"]
 ```
 
 


### PR DESCRIPTION
I wasn't able to include liberator-transit when I noticed that it didn't match on clojars.
