### PR TITLE
prop/for-all needs `and` for multiple conditions

### DIFF
--- a/test/io/clojure/liberator_transit_test.clj
+++ b/test/io/clojure/liberator_transit_test.clj
@@ -124,16 +124,16 @@
 (defspec generated-sequences
   num-generative-tests
   (prop/for-all [v gen/sequence-generator]
-    (= (jsonify v) (to-string ((test-resource v) (json-request))))
-    (= (jsonify v :verbose) (to-string ((test-resource v) (json-request :verbose))))
-    (= (packify v) (to-bytes ((test-resource v) (msgpack-request))))))
+    (and (= (jsonify v) (to-string ((test-resource v) (json-request))))
+         (= (jsonify v :verbose) (to-string ((test-resource v) (json-request :verbose))))
+         (= (packify v) (to-bytes ((test-resource v) (msgpack-request)))))))
 
 (defspec generated-maps
   num-generative-tests
   (prop/for-all [v gen/map-generator]
-    (= (jsonify v) (to-string ((test-resource v) (json-request))))
-    (= (jsonify v :verbose) (to-string ((test-resource v) (json-request :verbose))))
-    (= (packify v) (to-bytes ((test-resource v) (msgpack-request))))))
+    (and (= (jsonify v) (to-string ((test-resource v) (json-request))))
+         (= (jsonify v :verbose) (to-string ((test-resource v) (json-request :verbose))))
+         (= (packify v) (to-bytes ((test-resource v) (msgpack-request)))))))
 
 (defmethod assert-expr 'invalid-buffer-error?
   [msg form]


### PR DESCRIPTION
The `prop/for-all` usage needs to wrap multiple conditions in an `and` so that they all get tested properly.  It works like the body of a function to test, not a sequence of tests.